### PR TITLE
Fix prefixConnect missing implementation in iOS

### DIFF
--- a/ios/Classes/SwiftPluginWifiConnectPlugin.swift
+++ b/ios/Classes/SwiftPluginWifiConnectPlugin.swift
@@ -28,7 +28,7 @@ public class SwiftPluginWifiConnectPlugin: NSObject, FlutterPlugin {
           connect(hotspotConfig: hotspotConfig, result: result)
           return
 
-        case "  ":
+        case "prefixConnect":
           guard #available(iOS 13.0, *) else {
             result(FlutterError(code: "iOS must be above 13", message: "Prefix connect doesn't work on iOS pre 13", details: nil))
             return


### PR DESCRIPTION
# Description

I was trying to use the prefixConnect in iOS 17.5.1 and got missing plugin exception. After a quick look i saw that the function was implemented but the case was an empty string, instead of prefixConnect as used in the dart code.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Used the fork in my project and connected to a network just with the prefix of the SSID, worked right away.