### PR TITLE
Fix/android plus missing ios feature

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
First of all, thanks for this plugin, it helped me a lot.

I've found two issues:

* Android was not running in a freshly created flutter project due the following error

> Could not get unknown property 'flutter' for extension 'android' of type com.android.build.gradle.LibraryExtension.

* iOS implementation was missing the`prefixConnect` method implementation

As a plus the `CNCopySupportedInterfaces`[ is deprecated](https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo). I've updated the `getSSID` method as well