### PR TITLE
chore(build.gradle): fixed an extra bracket error

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter())
+        jcenter()
     }
 }
 


### PR DESCRIPTION
This PR fixes a minor bracket issue in example/android/build gradle file